### PR TITLE
Fixed bug with improper dom-utils usage

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -203,8 +203,8 @@ class Modal extends React.Component {
     return {
       dialog: {
         zIndex: getZIndex('modal'),
-        paddingRight: bodyIsOverflowing && !modalIsOverflowing ? scrollbarWidth : void 0,
-        paddingLeft:  !bodyIsOverflowing && modalIsOverflowing ? scrollbarWidth : void 0
+        paddingRight: bodyIsOverflowing && !modalIsOverflowing ? scrollbarWidth() : void 0,
+        paddingLeft:  !bodyIsOverflowing && modalIsOverflowing ? scrollbarWidth() : void 0
       },
       backdrop: {
         zIndex: getZIndex('backdrop')


### PR DESCRIPTION
Hello.

I am ending with this in DOM:
```
<div style="z-index:1050;padding-right:function (recalc) {
  if (!size || recalc) {
    if (canUseDOM) {
      var scrollDiv = document.createElement('div');

      scrollDiv.style.position = 'absolute';
      scrollDiv.style.top = '-9999px';
      scrollDiv.style.width = '50px';
      scrollDiv.style.height = '50px';
      scrollDiv.style.overflow = 'scroll';

      document.body.appendChild(scrollDiv);
      size = scrollDiv.offsetWidth - scrollDiv.clientWidth;
      document.body.removeChild(scrollDiv);
    }
  }

  return size;
};" 
```

That is because the function for measuring the scrollbar width is not being called, it is just being referenced.