### PR TITLE
remove reference to "document" for server-side rendering

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -68,7 +68,7 @@ class Modal extends React.Component {
     keyboard:           true,
     animate:            true,
     transition:         true,
-    container:          typeof window != 'undefined' ? document.body : null,
+    container:          canUseDOM ? document.body : null,
     attentionClass: 'shake',
   }
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -68,7 +68,7 @@ class Modal extends React.Component {
     keyboard:           true,
     animate:            true,
     transition:         true,
-    container:          document.body,
+    container:          typeof window != 'undefined' ? document.body : null,
     attentionClass: 'shake',
   }
 


### PR DESCRIPTION
allow <Modal> to be used in node.js context where document object is not defined (it's not expected that the modal would actually be rendered but at least it shouldn't break everything else)