### PR TITLE
Upgrade React and use standalone `prop-types` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "defaultDryRun": "false"
   },
   "peerDependencies": {
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react": "^0.14.9 || >= 15.3.0",
+    "react-dom": "^0.14.9 || >= 15.3.0"
   },
   "devDependencies": {
     "@monastic.panic/component-playground": "^2.0.0",
@@ -65,8 +65,8 @@
     "lolex": "^1.4.0",
     "mocha": "^2.4.5",
     "raw-loader": "^0.5.1",
-    "react": "^15.3.1",
-    "react-dom": "^15.3.1",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "release-script": "^1.0.2",
     "rimraf": "^2.4.3",
     "simulant": "^0.2.0",
@@ -80,6 +80,7 @@
   "dependencies": {
     "classnames": "^2.2.3",
     "dom-helpers": "^2.2.4",
+    "prop-types": "^15.5.8",
     "react-overlays": "^0.6.10",
     "react-prop-types": "^0.4.0"
   }

--- a/src/Body.js
+++ b/src/Body.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import cn from 'classnames';
 
 class ModalBody extends React.Component {
@@ -24,7 +25,7 @@ ModalBody.propTypes = {
   /**
    * A css class applied to the Component
    */
-  modalPrefix: React.PropTypes.string
+  modalPrefix: PropTypes.string
 };
 
 export default ModalBody

--- a/src/Dismiss.js
+++ b/src/Dismiss.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 let chain = (a, b) => (...args) => {
   a && a(...args)
@@ -8,9 +9,9 @@ let chain = (a, b) => (...args) => {
 class Dismiss extends React.Component {
 
   static propTypes = {
-    component:  React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.func
+    component:  PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func
     ])
   }
 
@@ -19,7 +20,7 @@ class Dismiss extends React.Component {
   }
 
   static contextTypes = {
-    onModalHide: React.PropTypes.func
+    onModalHide: PropTypes.func
   }
 
   render() {

--- a/src/Footer.js
+++ b/src/Footer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import cn from 'classnames';
 
 class ModalFooter extends React.Component {
@@ -23,7 +24,7 @@ ModalFooter.propTypes = {
   /**
    * A css class applied to the Component
    */
-  modalPrefix: React.PropTypes.string
+  modalPrefix: PropTypes.string
 };
 
 

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import cn from 'classnames';
 
 import Dismiss from './Dismiss';
@@ -11,13 +12,13 @@ class ModalHeader extends React.Component {
     return 'modal'
   }
   static propTypes = {
-    closeButton: React.PropTypes.bool,
+    closeButton: PropTypes.bool,
     /**
      * A css class applied to the Component
      */
-    modalPrefix: React.PropTypes.string,
+    modalPrefix: PropTypes.string,
 
-    'aria-label': React.PropTypes.string,
+    'aria-label': PropTypes.string,
   }
 
   static defaultProps = {
@@ -26,7 +27,7 @@ class ModalHeader extends React.Component {
   }
 
   static contextTypes = {
-    onModalHide: React.PropTypes.func
+    onModalHide: PropTypes.func
   }
 
   render() {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,4 +1,5 @@
 import React  from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 
 import BaseModal from 'react-overlays/lib/Modal';
@@ -36,32 +37,32 @@ class Modal extends React.Component {
   }
 
   static propTypes = {
-    show: React.PropTypes.bool,
+    show: PropTypes.bool,
 
     /** sizes **/
-    small: React.PropTypes.bool,
-    sm: React.PropTypes.bool,
-    large: React.PropTypes.bool,
-    lg: React.PropTypes.bool,
+    small: PropTypes.bool,
+    sm: PropTypes.bool,
+    large: PropTypes.bool,
+    lg: PropTypes.bool,
     /** --- **/
 
-    backdrop: React.PropTypes.oneOf(['static', true, false]),
-    keyboard: React.PropTypes.bool,
-    animate: React.PropTypes.bool,
-    transition: React.PropTypes.any,
-    container: React.PropTypes.oneOfType([componentOrElement, React.PropTypes.func]),
+    backdrop: PropTypes.oneOf(['static', true, false]),
+    keyboard: PropTypes.bool,
+    animate: PropTypes.bool,
+    transition: PropTypes.any,
+    container: PropTypes.oneOfType([componentOrElement, PropTypes.func]),
 
-    onHide: React.PropTypes.func,
-    onEnter: React.PropTypes.func,
-    onEntering: React.PropTypes.func,
-    onEntered: React.PropTypes.func,
-    onExit: React.PropTypes.func,
-    onExiting: React.PropTypes.func,
-    onExited: React.PropTypes.func,
+    onHide: PropTypes.func,
+    onEnter: PropTypes.func,
+    onEntering: PropTypes.func,
+    onEntered: PropTypes.func,
+    onExit: PropTypes.func,
+    onExiting: PropTypes.func,
+    onExited: PropTypes.func,
 
-    modalPrefix: React.PropTypes.string,
-    dialogClassName: React.PropTypes.string,
-    attentionClass: React.PropTypes.string,
+    modalPrefix: PropTypes.string,
+    dialogClassName: PropTypes.string,
+    attentionClass: PropTypes.string,
   }
 
   static defaultProps = {
@@ -78,7 +79,7 @@ class Modal extends React.Component {
   }
 
   static childContextTypes = {
-    onModalHide: React.PropTypes.func
+    onModalHide: PropTypes.func
   }
 
   getChildContext(){

--- a/src/Title.js
+++ b/src/Title.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import cn from 'classnames';
 
 class ModalTitle extends React.Component {
@@ -6,7 +7,7 @@ class ModalTitle extends React.Component {
     /**
      * A css class applied to the Component
      */
-    modalPrefix: React.PropTypes.string
+    modalPrefix: PropTypes.string
   }
 
   static getDefaultPrefix() {


### PR DESCRIPTION
Upgrades peerDependencies to request the standalone `prop-types` package.