### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/Body.js
+++ b/lib/Body.js
@@ -8,6 +8,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
@@ -36,12 +40,11 @@ var ModalBody = function (_React$Component) {
   };
 
   ModalBody.prototype.render = function render() {
-    var _props = this.props;
-    var modalPrefix = _props.modalPrefix;
-    var children = _props.children;
-    var className = _props.className;
-
-    var props = _objectWithoutProperties(_props, ['modalPrefix', 'children', 'className']);
+    var _props = this.props,
+        modalPrefix = _props.modalPrefix,
+        children = _props.children,
+        className = _props.className,
+        props = _objectWithoutProperties(_props, ['modalPrefix', 'children', 'className']);
 
     var prefix = modalPrefix || ModalBody.getDefaultPrefix();
 
@@ -59,7 +62,7 @@ ModalBody.propTypes = {
   /**
    * A css class applied to the Component
    */
-  modalPrefix: _react2.default.PropTypes.string
+  modalPrefix: _propTypes2.default.string
 };
 
 exports.default = ModalBody;

--- a/lib/Dismiss.js
+++ b/lib/Dismiss.js
@@ -8,6 +8,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
@@ -35,11 +39,10 @@ var Dismiss = function (_React$Component) {
   }
 
   Dismiss.prototype.render = function render() {
-    var _props = this.props;
-    var Tag = _props.component;
-    var children = _props.children;
-
-    var props = _objectWithoutProperties(_props, ['component', 'children']);
+    var _props = this.props,
+        Tag = _props.component,
+        children = _props.children,
+        props = _objectWithoutProperties(_props, ['component', 'children']);
 
     return _react2.default.createElement(
       Tag,
@@ -54,13 +57,13 @@ var Dismiss = function (_React$Component) {
 }(_react2.default.Component);
 
 Dismiss.propTypes = {
-  component: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.func])
+  component: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func])
 };
 Dismiss.defaultProps = {
   component: 'button'
 };
 Dismiss.contextTypes = {
-  onModalHide: _react2.default.PropTypes.func
+  onModalHide: _propTypes2.default.func
 };
 exports.default = Dismiss;
 module.exports = exports['default'];

--- a/lib/Footer.js
+++ b/lib/Footer.js
@@ -8,6 +8,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
@@ -36,12 +40,11 @@ var ModalFooter = function (_React$Component) {
   };
 
   ModalFooter.prototype.render = function render() {
-    var _props = this.props;
-    var modalPrefix = _props.modalPrefix;
-    var children = _props.children;
-    var className = _props.className;
-
-    var props = _objectWithoutProperties(_props, ['modalPrefix', 'children', 'className']);
+    var _props = this.props,
+        modalPrefix = _props.modalPrefix,
+        children = _props.children,
+        className = _props.className,
+        props = _objectWithoutProperties(_props, ['modalPrefix', 'children', 'className']);
 
     var prefix = modalPrefix || ModalFooter.getDefaultPrefix();
 
@@ -59,7 +62,7 @@ ModalFooter.propTypes = {
   /**
    * A css class applied to the Component
    */
-  modalPrefix: _react2.default.PropTypes.string
+  modalPrefix: _propTypes2.default.string
 };
 
 exports.default = ModalFooter;

--- a/lib/Header.js
+++ b/lib/Header.js
@@ -8,6 +8,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
@@ -40,14 +44,13 @@ var ModalHeader = function (_React$Component) {
   };
 
   ModalHeader.prototype.render = function render() {
-    var _props = this.props;
-    var modalPrefix = _props.modalPrefix;
-    var closeButton = _props.closeButton;
-    var children = _props.children;
-    var className = _props.className;
-    var label = _props['aria-label'];
-
-    var props = _objectWithoutProperties(_props, ['modalPrefix', 'closeButton', 'children', 'className', 'aria-label']);
+    var _props = this.props,
+        modalPrefix = _props.modalPrefix,
+        closeButton = _props.closeButton,
+        children = _props.children,
+        className = _props.className,
+        label = _props['aria-label'],
+        props = _objectWithoutProperties(_props, ['modalPrefix', 'closeButton', 'children', 'className', 'aria-label']);
 
     var prefix = modalPrefix || ModalHeader.getDefaultPrefix();
 
@@ -65,7 +68,7 @@ var ModalHeader = function (_React$Component) {
         _react2.default.createElement(
           'span',
           { 'aria-hidden': 'true' },
-          '×'
+          '\xD7'
         )
       ),
       children
@@ -77,20 +80,20 @@ var ModalHeader = function (_React$Component) {
 
 ModalHeader._isModalHeader = true;
 ModalHeader.propTypes = {
-  closeButton: _react2.default.PropTypes.bool,
+  closeButton: _propTypes2.default.bool,
   /**
    * A css class applied to the Component
    */
-  modalPrefix: _react2.default.PropTypes.string,
+  modalPrefix: _propTypes2.default.string,
 
-  'aria-label': _react2.default.PropTypes.string
+  'aria-label': _propTypes2.default.string
 };
 ModalHeader.defaultProps = {
   closeButton: false,
   'aria-label': 'Close Modal'
 };
 ModalHeader.contextTypes = {
-  onModalHide: _react2.default.PropTypes.func
+  onModalHide: _propTypes2.default.func
 };
 exports.default = ModalHeader;
 module.exports = exports['default'];

--- a/lib/Modal.js
+++ b/lib/Modal.js
@@ -8,6 +8,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactDom = require('react-dom');
 
 var _Modal = require('react-overlays/lib/Modal');
@@ -158,25 +162,24 @@ var Modal = function (_React$Component) {
   Modal.prototype.render = function render() {
     var _this3 = this;
 
-    var _props = this.props;
-    var className = _props.className;
-    var children = _props.children;
-    var keyboard = _props.keyboard;
-    var transition = _props.transition;
-    var modalPrefix = _props.modalPrefix;
-    var dialogClassName = _props.dialogClassName;
-    var container = _props.container;
-    var onEnter = _props.onEnter;
-    var onEntered = _props.onEntered;
-    var onExit = _props.onExit;
-    var onExited = _props.onExited;
+    var _props = this.props,
+        className = _props.className,
+        children = _props.children,
+        keyboard = _props.keyboard,
+        transition = _props.transition,
+        modalPrefix = _props.modalPrefix,
+        dialogClassName = _props.dialogClassName,
+        container = _props.container,
+        onEnter = _props.onEnter,
+        onEntered = _props.onEntered,
+        onExit = _props.onExit,
+        onExited = _props.onExited,
+        props = _objectWithoutProperties(_props, ['className', 'children', 'keyboard', 'transition', 'modalPrefix', 'dialogClassName', 'container', 'onEnter', 'onEntered', 'onExit', 'onExited']);
 
-    var props = _objectWithoutProperties(_props, ['className', 'children', 'keyboard', 'transition', 'modalPrefix', 'dialogClassName', 'container', 'onEnter', 'onEntered', 'onExit', 'onExited']);
-
-    var _state = this.state;
-    var dialog = _state.dialog;
-    var classes = _state.classes;
-    var backdrop = _state.backdrop;
+    var _state = this.state,
+        dialog = _state.dialog,
+        classes = _state.classes,
+        backdrop = _state.backdrop;
 
 
     delete props.manager;
@@ -299,32 +302,32 @@ var Modal = function (_React$Component) {
 }(_react2.default.Component);
 
 Modal.propTypes = {
-  show: _react2.default.PropTypes.bool,
+  show: _propTypes2.default.bool,
 
   /** sizes **/
-  small: _react2.default.PropTypes.bool,
-  sm: _react2.default.PropTypes.bool,
-  large: _react2.default.PropTypes.bool,
-  lg: _react2.default.PropTypes.bool,
+  small: _propTypes2.default.bool,
+  sm: _propTypes2.default.bool,
+  large: _propTypes2.default.bool,
+  lg: _propTypes2.default.bool,
   /** --- **/
 
-  backdrop: _react2.default.PropTypes.oneOf(['static', true, false]),
-  keyboard: _react2.default.PropTypes.bool,
-  animate: _react2.default.PropTypes.bool,
-  transition: _react2.default.PropTypes.any,
-  container: _react2.default.PropTypes.oneOfType([_componentOrElement2.default, _react2.default.PropTypes.func]),
+  backdrop: _propTypes2.default.oneOf(['static', true, false]),
+  keyboard: _propTypes2.default.bool,
+  animate: _propTypes2.default.bool,
+  transition: _propTypes2.default.any,
+  container: _propTypes2.default.oneOfType([_componentOrElement2.default, _propTypes2.default.func]),
 
-  onHide: _react2.default.PropTypes.func,
-  onEnter: _react2.default.PropTypes.func,
-  onEntering: _react2.default.PropTypes.func,
-  onEntered: _react2.default.PropTypes.func,
-  onExit: _react2.default.PropTypes.func,
-  onExiting: _react2.default.PropTypes.func,
-  onExited: _react2.default.PropTypes.func,
+  onHide: _propTypes2.default.func,
+  onEnter: _propTypes2.default.func,
+  onEntering: _propTypes2.default.func,
+  onEntered: _propTypes2.default.func,
+  onExit: _propTypes2.default.func,
+  onExiting: _propTypes2.default.func,
+  onExited: _propTypes2.default.func,
 
-  modalPrefix: _react2.default.PropTypes.string,
-  dialogClassName: _react2.default.PropTypes.string,
-  attentionClass: _react2.default.PropTypes.string
+  modalPrefix: _propTypes2.default.string,
+  dialogClassName: _propTypes2.default.string,
+  attentionClass: _propTypes2.default.string
 };
 Modal.defaultProps = {
   backdrop: true,
@@ -336,7 +339,7 @@ Modal.defaultProps = {
   manager: (_Modal2.default.getDefaultProps ? _Modal2.default.getDefaultProps() : _Modal2.default.defaultProps).manager
 };
 Modal.childContextTypes = {
-  onModalHide: _react2.default.PropTypes.func
+  onModalHide: _propTypes2.default.func
 };
 
 

--- a/lib/Title.js
+++ b/lib/Title.js
@@ -8,6 +8,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
@@ -36,11 +40,10 @@ var ModalTitle = function (_React$Component) {
   };
 
   ModalTitle.prototype.render = function render() {
-    var _props = this.props;
-    var modalPrefix = _props.modalPrefix;
-    var className = _props.className;
-
-    var props = _objectWithoutProperties(_props, ['modalPrefix', 'className']);
+    var _props = this.props,
+        modalPrefix = _props.modalPrefix,
+        className = _props.className,
+        props = _objectWithoutProperties(_props, ['modalPrefix', 'className']);
 
     var prefix = modalPrefix || ModalTitle.getDefaultPrefix();
 
@@ -56,7 +59,7 @@ ModalTitle.propTypes = {
   /**
    * A css class applied to the Component
    */
-  modalPrefix: _react2.default.PropTypes.string
+  modalPrefix: _propTypes2.default.string
 };
 exports.default = ModalTitle;
 module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "classnames": "^2.2.3",
     "dom-helpers": "^2.2.4",
-    "prop-types": "^15.5.8",
+    "prop-types": "^15.6.0",
     "react-overlays": "^0.7.3",
     "react-prop-types": "^0.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "classnames": "^2.2.3",
     "dom-helpers": "^2.2.4",
     "prop-types": "^15.5.8",
-    "react-overlays": "^0.6.10",
+    "react-overlays": "^0.7.3",
     "react-prop-types": "^0.4.0"
   }
 }


### PR DESCRIPTION
- Update version of react-overlays
- Update version of react-props
- Build JS files (it seems some work had been done to prevent deprecation warnings, but the lib files were never rebuilt).
- This PR cleans deprecation warning about accessing createClass and accessing PropTypes